### PR TITLE
chore: add GitHub Actions release pipeline (TestPyPI + PyPI + GitHub Release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,15 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
+      - name: Verify version matches tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if [ "$TAG" != "$PKG_VERSION" ]; then
+            echo "::error::Tag v$TAG does not match pyproject.toml version $PKG_VERSION"
+            exit 1
+          fi
+
       - name: Build package
         run: uv build
 
@@ -73,11 +82,13 @@ jobs:
           name: dist
           path: dist/
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: >
-          gh release create "${{ github.ref_name }}"
-          dist/*
-          --generate-notes
-          --title "Release ${{ github.ref_name }}"
+        run: |
+          TAG="${{ github.ref_name }}"
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            gh release upload "$TAG" dist/* --clobber
+          else
+            gh release create "$TAG" dist/* --generate-notes --title "Release $TAG"
+          fi


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` triggered on `v*` tag push with 4 sequential jobs:

1. **build** — `uv build` produces sdist + wheel, uploaded as artifact
2. **publish-testpypi** — OIDC trusted publish to TestPyPI (gate before production)
3. **publish-pypi** — OIDC trusted publish to PyPI
4. **github-release** — Creates GitHub Release with auto-generated notes and dist assets

Key design:
- OIDC trusted publishing (no API tokens stored)
- Build once, publish same artifact everywhere
- Minimal permissions per job (id-token: write for publish, contents: write for release)

Closes #8

## Post-merge setup required

1. Create `llm-budget` project on [TestPyPI](https://test.pypi.org) and [PyPI](https://pypi.org)
2. Configure trusted publishers on both pointing to this repo + `release.yml` workflow
3. Optionally create `pypi` and `testpypi` GitHub environments for protection rules

## Test plan

- [x] Existing CI (173 tests) still passes — no Python code changed
- [x] Workflow syntax validated manually
- [x] Job names match /release command expectations