### PR TITLE
chore: round costs to prevent floating-point drift

### DIFF
--- a/src/llm_toll/_postgres_store.py
+++ b/src/llm_toll/_postgres_store.py
@@ -144,7 +144,7 @@ class PostgresStore(BaseStore):
                         max_budget=max_budget,
                     )
 
-                new_total = current_cost + cost
+                new_total = round(current_cost + cost, 10)
                 if new_total > max_budget:
                     raise BudgetExceededError(
                         project=project,

--- a/src/llm_toll/_postgres_store.py
+++ b/src/llm_toll/_postgres_store.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from llm_toll.exceptions import BudgetExceededError
+from llm_toll.pricing import COST_ROUND_PLACES
 from llm_toll.store import BaseStore, _utc_now_iso
 
 
@@ -144,7 +145,7 @@ class PostgresStore(BaseStore):
                         max_budget=max_budget,
                     )
 
-                new_total = round(current_cost + cost, 10)
+                new_total = round(current_cost + cost, COST_ROUND_PLACES)
                 if new_total > max_budget:
                     raise BudgetExceededError(
                         project=project,

--- a/src/llm_toll/pricing.py
+++ b/src/llm_toll/pricing.py
@@ -38,9 +38,13 @@ _BUILTIN_PRICING: dict[str, tuple[float, float]] = {
 }
 
 
+COST_ROUND_PLACES: int = 10
+"""Number of decimal places to round costs to, preventing floating-point drift."""
+
+
 def _calc(input_tokens: int, output_tokens: int, pricing: tuple[float, float]) -> float:
-    """Compute cost and round to 10 decimal places to prevent drift."""
-    return round(input_tokens * pricing[0] + output_tokens * pricing[1], 10)
+    """Compute cost and round to :data:`COST_ROUND_PLACES` decimal places."""
+    return round(input_tokens * pricing[0] + output_tokens * pricing[1], COST_ROUND_PLACES)
 
 
 class PricingRegistry:

--- a/src/llm_toll/pricing.py
+++ b/src/llm_toll/pricing.py
@@ -38,6 +38,11 @@ _BUILTIN_PRICING: dict[str, tuple[float, float]] = {
 }
 
 
+def _calc(input_tokens: int, output_tokens: int, pricing: tuple[float, float]) -> float:
+    """Compute cost and round to 10 decimal places to prevent drift."""
+    return round(input_tokens * pricing[0] + output_tokens * pricing[1], 10)
+
+
 class PricingRegistry:
     """In-memory store of per-model cost-per-token pricing.
 
@@ -114,23 +119,23 @@ class PricingRegistry:
         """
         pricing = self._models.get(model)
         if pricing is not None:
-            return input_tokens * pricing[0] + output_tokens * pricing[1]
+            return _calc(input_tokens, output_tokens, pricing)
 
         # Try prefix match — find the longest registered key that is a prefix of model
         pricing = self._resolve_prefix(model)
         if pricing is not None:
-            return input_tokens * pricing[0] + output_tokens * pricing[1]
+            return _calc(input_tokens, output_tokens, pricing)
 
         # Fallback or unknown — guard with lock for atomic check-and-cache
         with self._lock:
             # Re-check under lock (another thread may have resolved it)
             pricing = self._models.get(model)
             if pricing is not None:
-                return input_tokens * pricing[0] + output_tokens * pricing[1]
+                return _calc(input_tokens, output_tokens, pricing)
 
             if self._fallback is not None:
                 self._cache_dynamic(model, self._fallback)
-                return input_tokens * self._fallback[0] + output_tokens * self._fallback[1]
+                return _calc(input_tokens, output_tokens, self._fallback)
 
             # Unknown model — warn once, then cache (0, 0)
             warnings.warn(

--- a/src/llm_toll/reporter.py
+++ b/src/llm_toll/reporter.py
@@ -49,7 +49,7 @@ class CostReporter:
     ) -> None:
         """Print a per-call cost summary and update session accumulators."""
         with self._lock:
-            self._session_cost += cost
+            self._session_cost = round(self._session_cost + cost, 10)
             self._session_input_tokens += input_tokens
             self._session_output_tokens += output_tokens
             self._call_count += 1

--- a/src/llm_toll/reporter.py
+++ b/src/llm_toll/reporter.py
@@ -7,6 +7,8 @@ import sys
 import threading
 from typing import IO
 
+from llm_toll.pricing import COST_ROUND_PLACES
+
 # ANSI color codes
 _CYAN = "36"
 _GREEN = "32"
@@ -49,7 +51,7 @@ class CostReporter:
     ) -> None:
         """Print a per-call cost summary and update session accumulators."""
         with self._lock:
-            self._session_cost = round(self._session_cost + cost, 10)
+            self._session_cost = round(self._session_cost + cost, COST_ROUND_PLACES)
             self._session_input_tokens += input_tokens
             self._session_output_tokens += output_tokens
             self._call_count += 1

--- a/src/llm_toll/store.py
+++ b/src/llm_toll/store.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from llm_toll.exceptions import BudgetExceededError
+from llm_toll.pricing import COST_ROUND_PLACES
 
 
 class BaseStore(ABC):
@@ -266,7 +267,7 @@ class SQLiteStore(BaseStore):
                             max_budget=max_budget,
                         )
 
-                    new_total = round(current_cost + cost, 10)
+                    new_total = round(current_cost + cost, COST_ROUND_PLACES)
                     if new_total > max_budget:
                         raise BudgetExceededError(
                             project=project,

--- a/src/llm_toll/store.py
+++ b/src/llm_toll/store.py
@@ -266,7 +266,7 @@ class SQLiteStore(BaseStore):
                             max_budget=max_budget,
                         )
 
-                    new_total = current_cost + cost
+                    new_total = round(current_cost + cost, 10)
                     if new_total > max_budget:
                         raise BudgetExceededError(
                             project=project,

--- a/tests/unit/test_pricing.py
+++ b/tests/unit/test_pricing.py
@@ -337,3 +337,23 @@ class TestBoundedCache:
             f"Cache grew to {len(registry._models)} entries, "
             f"expected at most {max_allowed} (builtin={builtin_count})"
         )
+
+
+class TestCostRounding:
+    """Tests that cost calculation rounds to prevent floating-point drift."""
+
+    def test_get_cost_is_rounded(self) -> None:
+        """Cost should be cleanly rounded, not have floating-point noise."""
+        registry = PricingRegistry()
+        # gpt-4o: input=2.5e-06, output=10.0e-06
+        # 1000 * 2.5e-06 + 500 * 10.0e-06 = 0.0025 + 0.005 = 0.0075
+        cost = registry.get_cost("gpt-4o", 1000, 500)
+        assert cost == 0.0075  # exact, no floating-point noise
+
+    def test_no_drift_after_many_accumulations(self) -> None:
+        """Summing many rounded costs should not drift."""
+        registry = PricingRegistry()
+        single = registry.get_cost("gpt-4o", 100, 50)
+        total = sum(registry.get_cost("gpt-4o", 100, 50) for _ in range(10000))
+        expected = round(single * 10000, 10)
+        assert total == pytest.approx(expected, abs=1e-9)


### PR DESCRIPTION
## Summary

- Round get_cost() results to 10 decimal places via _calc() helper in pricing.py
- Round budget accumulation (new_total) in SQLiteStore and PostgresStore
- Round session cost accumulation in CostReporter
- Prevents visible drift after thousands of calls without any schema changes

Closes #22

## Test plan

- 2 new rounding tests (exact cost, no drift after 10k accumulations)
- All 362 tests pass, 89.49% coverage