### PR TITLE
chore(ci): cap release artifact retention at 7 days

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           name: dist
           path: dist/
+          retention-days: 7
 
   publish-testpypi:
     needs: build


### PR DESCRIPTION
## Summary
Adds `retention-days: 7` to the `upload-artifact` step(s) in `release.yml`.

## Why
These workflow artifacts duplicate the GitHub Release assets (free, unlimited storage) and had no retention set, so they defaulted to **90 days** and accumulated against the account-wide Actions storage quota (which passed 90%). The backlog has already been purged; this caps re-accumulation.

No functional change to builds or releases.